### PR TITLE
Feat/US2.3 - Intégration dynamique du catalogue avec service HTTP et modal d’erreur amélioré

### DIFF
--- a/qml/logic/CatalogueLogic.qml
+++ b/qml/logic/CatalogueLogic.qml
@@ -25,14 +25,15 @@ Item {
 
         // Traitement du résultat positif à la réception du signal
         function onFilmsFetched(films) {
-            loading = false
-            Model.FilmDataSingletonModel.updateFromAPI = films.map(function(f) {
-                return {
-                    id: f.id,
-                    title: f.title,
-                    poster_url: f.poster_url
-                }
-            })
+            Model.FilmDataSingletonModel.updateFromAPI(
+                films.map(function(f) {
+                    return {
+                        id: f.id,
+                        title: f.title,
+                        poster_url: f.poster_url
+                    }
+                })
+            )
         }
 
         // Gestion des erreurs

--- a/qml/logic/CatalogueLogic.qml
+++ b/qml/logic/CatalogueLogic.qml
@@ -1,10 +1,9 @@
 import QtQuick 2.15
 import Felgo 4.0
-import "../model/FilmService.qml" as Service
-import "../model/FilmDataSingletonModel.qml" as Model
+import "../model" as Model
 
 Item {
-    id: catalog_logic
+    id: catalogueLogic
 
     // Indicateur d’état de chargement
     property bool loading: false
@@ -13,7 +12,7 @@ Item {
     signal errorOccurred(string message)
 
     // Instance du service HTTP
-    Service {
+    Model.FilmService {
         id: filmService
     }
 

--- a/qml/logic/CatalogueLogic.qml
+++ b/qml/logic/CatalogueLogic.qml
@@ -7,8 +7,9 @@ Item {
 
     // Propriétés exposées à la vue
     readonly property bool loading: Model.FilmDataSingletonModel.isLoading        // Indicateur d’état de chargement
-    readonly property bool hasData: Model.FilmDataSingletonModel.hasRealData
+    property bool hasData: Model.FilmDataSingletonModel.films && Model.FilmDataSingletonModel.films.length > 0
     readonly property string errorMessage: Model.FilmDataSingletonModel.lastError
+    readonly property int filmCount: Model.FilmDataSingletonModel.films.length
 
     // Signal pour propager les erreurs à la vue
     signal errorOccurred(string message)
@@ -70,15 +71,19 @@ Item {
      */
     function useTestData() {
         Model.FilmDataSingletonModel.useTestData()
+        // Forcer une mise à jour immédiate
+        filmCount = Model.FilmDataSingletonModel.films.length
+        hasData = filmCount > 0
+        errorMessage = ""
     }
 
     // Chargement automatique au démarrage
     Component.onCompleted: {
         // Charger depuis l'API
-        Qt.callLater(refreshCatalogue)
+        // Qt.callLater(refreshCatalogue)
 
         // Utiliser les données de test (pour développement)
-        // Qt.callLater(useTestData)
+        Qt.callLater(useTestData)
     }
 
     // Chargement initial à l’affichage de la page

--- a/qml/logic/CatalogueLogic.qml
+++ b/qml/logic/CatalogueLogic.qml
@@ -7,9 +7,9 @@ Item {
 
     // Propriétés exposées à la vue
     readonly property bool loading: Model.FilmDataSingletonModel.isLoading        // Indicateur d’état de chargement
-    property bool hasData: Model.FilmDataSingletonModel.films && Model.FilmDataSingletonModel.films.length > 0
-    readonly property string errorMessage: Model.FilmDataSingletonModel.lastError
-    readonly property int filmCount: Model.FilmDataSingletonModel.films.length
+    property bool hasData: Model.FilmDataSingletonModel.films && Model.FilmDataSingletonModel.films.length > 0  // Pour détecter la liste de films vide
+    readonly property int filmCount: Model.FilmDataSingletonModel.films.length   // afficher le nombre de films dans le catalogue
+    readonly property string errorMessage: Model.FilmDataSingletonModel.lastError   // pour la gestion d'erreur
 
     // Signal pour propager les erreurs à la vue
     signal errorOccurred(string message)

--- a/qml/logic/CatalogueLogic.qml
+++ b/qml/logic/CatalogueLogic.qml
@@ -1,7 +1,54 @@
 import QtQuick 2.15
 import Felgo 4.0
+import "../model/FilmService.qml" as Service
+import "../model/FilmDataSingletonModel.qml" as Model
 
 Item {
     id: catalog_logic
+
+    // Indicateur d’état de chargement
+    property bool loading: false
+
+    // Signal pour propager les erreurs à la vue
+    signal errorOccurred(string message)
+
+    // Instance du service HTTP
+    Service {
+        id: filmService
+    }
+
+    // Connexion explicite aux signaux du service
+    Connections {
+        target: filmService
+
+        // Traitement du résultat positif
+        function onFilmsFetched(films) {
+            loading = false
+            Model.FilmDataSingletonModel.films = films.map(function(f) {
+                return {
+                    id: f.id,
+                    title: f.title,
+                    poster_url: f.poster_url
+                }
+            })
+        }
+
+        // Gestion des erreurs
+        function onFetchError(errorMessage) {
+            loading = false
+            errorOccurred(errorMessage)
+        }
+    }
+
+    /**
+     * Déclenche la récupération des films et affiche le loader
+     */
+    function refreshCatalogue() {
+        loading = true
+        filmService.fetchAllFilms()
+    }
+
+    // Chargement initial à l’affichage de la page
+    Component.onCompleted: refreshCatalogue()
 
 }

--- a/qml/model/FilmDataSingletonModel.qml
+++ b/qml/model/FilmDataSingletonModel.qml
@@ -8,9 +8,20 @@ Item {
     id: filmDataSingletonModel
     readonly property alias films: internal.films
 
+    // État de chargement initial
+    readonly property bool isLoading: internal.isLoading
+    readonly property alias hasRealData: internal.hasRealData
+    readonly property alias lastError: internal.lastError
+
     QtObject {
         id: internal
-        property var films: [
+
+        property bool isLoading: false
+        property bool hasRealData: false     // ← Indique si on a des vraies données API
+        property string lastError: ""        // ← Dernière erreur rencontrée
+
+        // Données de test
+        property var testFilms: [
             { id: 1, title: "Avatar", poster_url: "blue" },
             { id: 2, title: "Avengers: Endgame", poster_url: "red" },
             { id: 3, title: "Spider-Man: No Way Home", poster_url: "yellow" },
@@ -24,11 +35,56 @@ Item {
             { id: 11, title: "Forrest Gump", poster_url: "red" },
             { id: 12, title: "Gladiator", poster_url: "yellow" }
         ]
+
+        // Films actuels (vide au départ, rempli par l'API)
+        property var films: []  // ← Vide au démarrage !
+    }
+
+    /**
+     * Met à jour les films depuis l'API et marque comme "vraies données"
+     */
+    function updateFromAPI(newFilms) {
+        internal.isLoading = false
+        internal.films = newFilms
+        internal.hasRealData = true
+        internal.lastError = ""
+        console.log("Films mis à jour depuis l'API:", newFilms.length, "films chargés")
+    }
+
+    /**
+     * Gère une erreur de chargement
+     */
+    function setError(errorMessage) {
+        internal.isLoading = false
+        internal.lastError = errorMessage
+        // En cas d'erreur, on peut optionnellement garder les films existants
+        // ou utiliser les données de test comme fallback
+        console.log("Erreur de chargement:", errorMessage)
+    }
+
+    /**
+     * Démarre le chargement
+     */
+    function startLoading() {
+        internal.isLoading = true
+        internal.lastError = ""
+        console.log("Démarrage du chargement des films...")
+    }
+
+    /**
+     * Utilise les données de test (pour développement/fallback)
+     */
+    function useTestData() {
+        internal.films = internal.testFilms
+        internal.hasRealData = false
+        internal.isLoading = false
+        console.log("Utilisation des données de test:", internal.testFilms.length, "films")
     }
 
     Component.onCompleted: {
         console.log("=== DEBUG FilmDataModel ===")
-        console.log("FilmDataSingleton initialisé avec", films.length, "films populaires")
+        console.log("FilmDataSingleton initialisé - films:", films.length)
+        console.log("En attente de chargement API...")
         console.log(" ")
     }
 }

--- a/qml/model/FilmDataSingletonModel.qml
+++ b/qml/model/FilmDataSingletonModel.qml
@@ -44,9 +44,9 @@ Item {
      * Met à jour les films depuis l'API et marque comme "vraies données"
      */
     function updateFromAPI(newFilms) {
-        internal.isLoading = false
         internal.films = newFilms
         internal.hasRealData = true
+        internal.isLoading = false
         internal.lastError = ""
         console.log("Films mis à jour depuis l'API:", newFilms.length, "films chargés")
     }

--- a/qml/model/FilmDataSingletonModel.qml
+++ b/qml/model/FilmDataSingletonModel.qml
@@ -10,7 +10,6 @@ Item {
 
     // État de chargement initial
     readonly property bool isLoading: internal.isLoading
-    readonly property alias hasRealData: internal.hasRealData
     readonly property alias lastError: internal.lastError
 
     QtObject {
@@ -45,7 +44,6 @@ Item {
      */
     function updateFromAPI(newFilms) {
         internal.films = newFilms
-        internal.hasRealData = true
         internal.isLoading = false
         internal.lastError = ""
         console.log("Films mis à jour depuis l'API:", newFilms.length, "films chargés")
@@ -76,7 +74,6 @@ Item {
      */
     function useTestData() {
         internal.films = internal.testFilms
-        internal.hasRealData = false
         internal.isLoading = false
         console.log("Utilisation des données de test:", internal.testFilms.length, "films")
     }

--- a/qml/model/FilmDataSingletonModel.qml
+++ b/qml/model/FilmDataSingletonModel.qml
@@ -8,7 +8,7 @@ Item {
     id: filmDataSingletonModel
     readonly property alias films: internal.films
 
-    Item {
+    QtObject {
         id: internal
         property var films: [
             { id: 1, title: "Avatar", poster_url: "blue" },

--- a/qml/model/FilmService.qml
+++ b/qml/model/FilmService.qml
@@ -9,28 +9,28 @@ QtObject {
     signal filmsFetched(var films)
     signal fetchError(string errorMessage)
 
+    // Propriété (paramétrable)
+    property string apiUrl: "https://localhost:8000/api"
+
     /**
      * Récupère la liste de tous les films depuis l’API REST.
      * Émet filmsFetched(JSON) ou fetchError(message).
      */
     function fetchAllFilms() {
-        var request = new HttpRequest();
-        request.url = "https://localhost:8000/api/movies/";
-        request.method = "GET";
-        request.send();
-        request.onCompleted.connect(function(response) {
-            if (request.status === 200) {
-                try {
-                    filmsFetched(JSON.parse(response));
-                } catch(e) {
-                    fetchError("Réponse JSON invalide");
-                }
-            } else {
-                fetchError("Erreur HTTP : " + request.status);
+        let url = apiUrl + "/movies/";
+        HttpRequest.get(url)
+        .then(function(res) {
+            try {
+                filmsFetched(JSON.parse(response));
+            } catch(e) {
+                // Gestion JSON invalide
+                fetchError("Réponse JSON invalide");
+                console.warn("Erreur de parsing JSON:", e)
             }
-        });
-        request.onError.connect(function() {
-            fetchError("Échec de connexion au serveur");
-        });
+        })
+        .catch(function(error) {
+            fetchError("Erreur HTTP et/ou Échec de connexion au serveur : " + error);
+            console.error("Erreur récupération films:", error)
+        })
     }
 }

--- a/qml/model/FilmService.qml
+++ b/qml/model/FilmService.qml
@@ -1,0 +1,29 @@
+// qml/model/FilmService.qml
+import QtQuick 2.15
+import Felgo 4.0
+
+QtObject {
+    signal filmsFetched(var films)
+    signal fetchError(string errorMessage)
+
+    function fetchAllFilms() {
+        var request = new HttpRequest();
+        request.url = "https://api.monapp.com/films/";
+        request.method = "GET";
+        request.send();
+        request.onCompleted.connect(function(response) {
+            if (request.status === 200) {
+                try {
+                    filmsFetched(JSON.parse(response));
+                } catch(e) {
+                    fetchError("Réponse JSON invalide");
+                }
+            } else {
+                fetchError("Erreur HTTP : " + request.status);
+            }
+        });
+        request.onError.connect(function() {
+            fetchError("Échec de connexion au serveur");
+        });
+    }
+}

--- a/qml/model/FilmService.qml
+++ b/qml/model/FilmService.qml
@@ -2,13 +2,20 @@
 import QtQuick 2.15
 import Felgo 4.0
 
+// QtObject dédié aux appels réseau pour les films
 QtObject {
+
+    // Signaux émis en cas de succès ou d’erreur
     signal filmsFetched(var films)
     signal fetchError(string errorMessage)
 
+    /**
+     * Récupère la liste de tous les films depuis l’API REST.
+     * Émet filmsFetched(JSON) ou fetchError(message).
+     */
     function fetchAllFilms() {
         var request = new HttpRequest();
-        request.url = "https://api.monapp.com/films/";
+        request.url = "https://localhost:8000/api/movies/";
         request.method = "GET";
         request.send();
         request.onCompleted.connect(function(response) {

--- a/qml/model/qmldir
+++ b/qml/model/qmldir
@@ -1,1 +1,2 @@
 singleton FilmDataSingletonModel 1.0 FilmDataSingletonModel.qml
+FilmService 1.0 FilmService.qml

--- a/qml/pages/CataloguePage.qml
+++ b/qml/pages/CataloguePage.qml
@@ -181,7 +181,7 @@ AppPage {
 
         // Configuration modal partiel en bas
         fullscreen: false
-        modalHeight: dp(200)
+        modalHeight: dp(150)
 
         // Positionnement en bas (via ancrage du contenu)
         pushBackContent: cataloguePage
@@ -196,7 +196,7 @@ AppPage {
         // === CONTENU DU MODAL D'ERREUR ===
         Rectangle {
             id: modalContainer
-            width: Math.min(dp(350), parent.width * 0.9)
+            width: Math.min(dp(350), parent.width * 0.9)   // largeur contrôlée et responsive
             height: parent.height
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
@@ -215,8 +215,8 @@ AppPage {
 
             Column {
                 anchors.fill: parent
-                anchors.margins: dp(20)
-                spacing: dp(15)
+                anchors.margins: dp(10)
+                spacing: dp(12)
 
                 AppIcon {
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -238,7 +238,7 @@ AppPage {
 
                 Row {
                     anchors.horizontalCenter: parent.horizontalCenter
-                    spacing: dp(15)
+                    spacing: dp(20)
 
                     AppButton {
                         text: "Rejeter"
@@ -251,61 +251,13 @@ AppPage {
                         text: "Rafraîchir"
                         backgroundColor: Theme.colors.tintColor
                         onClicked: {
-                            errorModal.close()
+                            // errorModal.close()
                             logic.refreshCatalogue()
                         }
                     }
                 }
             }
         }
-
-        // Column {
-        //     anchors.fill: parent
-        //     anchors.margins: dp(20)
-        //     spacing: dp(15)
-
-        //     // Icône d'erreur
-        //     AppText {
-        //         anchors.horizontalCenter: parent.horizontalCenter
-        //         text: "⚠️"
-        //         font.pixelSize: sp(30)
-        //     }
-
-        //     // Message d'erreur
-        //     AppText {
-        //         id: errorText
-        //         anchors.horizontalCenter: parent.horizontalCenter
-        //         text: ""
-        //         color: Theme.colors.textColor
-        //         font.pixelSize: sp(14)
-        //         wrapMode: Text.WordWrap
-        //         horizontalAlignment: Text.AlignHCenter
-        //         maximumLineCount: 3
-        //         elide: Text.ElideRight
-        //     }
-
-        //     // Boutons d'action
-        //     Row {
-        //         anchors.horizontalCenter: parent.horizontalCenter
-        //         spacing: dp(15)
-
-        //         AppButton {
-        //             text: "Rejeter"
-        //             flat: true
-        //             textColor: Theme.colors.secondaryTextColor
-        //             onClicked: errorModal.close()
-        //         }
-
-        //         AppButton {
-        //             text: "Rafraîchir"
-        //             backgroundColor: Theme.colors.tintColor
-        //             onClicked: {
-        //                 errorModal.close()
-        //                 logic.refreshCatalogue()
-        //             }
-        //         }
-        //     }
-        // }
     }
 
     // === GESTION DES SIGNAUX ===

--- a/qml/pages/CataloguePage.qml
+++ b/qml/pages/CataloguePage.qml
@@ -34,7 +34,6 @@ AppPage {
     readonly property real gridTotalWidth: (fixedCardWidth * columns) + (itemSpacing * (columns - 1))
     readonly property real cellHeight: (fixedCardWidth * posterAspectRatio) + titleHeight
 
-
     // === LOGIQUE INTÉGRÉE ===
     Logic.CatalogueLogic{
         id: logic
@@ -67,7 +66,11 @@ AppPage {
 
         AppText {
             anchors.centerIn: parent
-            text: "Mon Catalogue"
+            text: logic.errorMessage
+                  ? "Mon Catalogue – Erreur"
+                  : logic.hasData
+                    ? "Mon Catalogue – " + logic.filmCount + " films"
+                    : "Mon Catalogue – Aucun film"
             font.pixelSize: sp(18)
             font.bold: true
             color: Theme.colors.textColor

--- a/qml/pages/CataloguePage.qml
+++ b/qml/pages/CataloguePage.qml
@@ -110,7 +110,7 @@ AppPage {
         id: gridContainer
         clip: true                                   // Cache tout ce qui sort des limites
         anchors.top: fixedHeader.bottom
-        anchors.topMargin: dp(5)
+        anchors.topMargin: dp(5)                     // Marge pour éviter le header
         anchors.horizontalCenter: parent.horizontalCenter
 
         width: gridTotalWidth
@@ -130,20 +130,9 @@ AppPage {
             // ← CONDITION : visible seulement si pas en chargement ET qu'il y a des films
             visible: !logic.loading && Model.FilmDataSingletonModel.films.length > 0
 
-            // anchors.top: fixedHeader.bottom
-            // anchors.horizontalCenter: parent.horizontalCenter
-            // // anchors.margins: dp(16)
-            // anchors.topMargin: dp(10) // Marge pour éviter le header
-
-            // width: gridTotalWidth
-
-            // height: parent.height - fixedHeader.height - dp(32)
-
             // A décommenter lorsqu'on aura de gros volume de films à afficher
             // cacheBuffer: cellHeight * 2
             // reuseItems: true
-
-
 
             // Opacité réduite pendant le chargement, mais visible
             // opacity: logic.loading ? 0.5 : 1.0

--- a/qml/pages/CataloguePage.qml
+++ b/qml/pages/CataloguePage.qml
@@ -1,7 +1,8 @@
 import Felgo 4.0
 import QtQuick 2.15
 import Qt5Compat.GraphicalEffects
-import "../model"
+import "../logic" as Logic
+import "../model" as Model
 
 AppPage {
     id: cataloguePage
@@ -31,6 +32,15 @@ AppPage {
 
     readonly property real gridTotalWidth: (fixedCardWidth * columns) + (itemSpacing * (columns - 1))
     readonly property real cellHeight: (fixedCardWidth * posterAspectRatio) + titleHeight
+
+    Logic.CatalogueLogic{
+        id: logic
+    }
+
+    // // === LOGIQUE INTÉGRÉE ===
+    // Logic.CatalogueLogic {
+    //     id: logic
+    // }
 
 
     // Header fixe au-dessus de tout
@@ -89,7 +99,7 @@ AppPage {
         // cacheBuffer: cellHeight * 2
         // reuseItems: true
 
-        model: FilmDataSingletonModel && FilmDataSingletonModel.films ? FilmDataSingletonModel.films : []
+        model: Model.FilmDataSingletonModel && Model.FilmDataSingletonModel.films ? Model.FilmDataSingletonModel.films : []
 
         delegate: Rectangle {
             width: fixedCardWidth  // Largeur dynamique
@@ -147,11 +157,11 @@ AppPage {
         console.log("Largeur grille totale:", gridTotalWidth)
         console.log("Largeur écran:", width)
         console.log("Espace restant:", (width - gridTotalWidth - dp(32)))
-        console.log("filmDataModel:", FilmDataSingletonModel)
-        if (FilmDataSingletonModel) {
-            console.log("filmDataModel.films:", FilmDataSingletonModel.films)
-            if (FilmDataSingletonModel.films) {
-                console.log("films.length:", FilmDataSingletonModel.films.length)
+        console.log("filmDataModel:", Model.FilmDataSingletonModel)
+        if (Model.FilmDataSingletonModel) {
+            console.log("filmDataModel.films:", Model.FilmDataSingletonModel.films)
+            if (Model.FilmDataSingletonModel.films) {
+                console.log("films.length:", Model.FilmDataSingletonModel.films.length)
             }
         }
     }

--- a/qml/pages/CataloguePage.qml
+++ b/qml/pages/CataloguePage.qml
@@ -198,8 +198,11 @@ AppPage {
             id: modalContainer
             width: Math.min(dp(350), parent.width * 0.9)   // largeur contrôlée et responsive
             height: parent.height
+
+            // Ancré en bas avec marge pour le décaler vers le haut
             anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: dp(40)
 
             radius: dp(12)
             color: Theme.colors.backgroundColor
@@ -221,7 +224,7 @@ AppPage {
                 AppIcon {
                     anchors.horizontalCenter: parent.horizontalCenter
                     iconType: IconType.exclamationtriangle
-                    // color: Theme.colors.dangerColor
+                    color: "#FFA500"
                     size: dp(24)
                 }
 


### PR DESCRIPTION
Mise en place d’un singleton FilmDataSingletonModel qui gère le catalogue des films avec séparation claire entre données de test et données API.

Création d’un service HTTP FilmService.qml paramétrable pour appeler l’API REST des films avec gestion des succès et erreurs.

Implémentation de la logique métier dans CatalogueLogic.qml avec liaison live au modèle, gestion des états chargement et erreur.

Création d’une page CataloguePage.qml responsive affichant une grille dynamique et un header fixe.

Ajout d’un modal d’erreur natif Felgo (AppModal) positionné en bas avec largeur contrôlée, textuel clair, et boutons “Rejeter” / “Rafraîchir” pour interaction utilisateur.

Correction des bugs de visibilité et réapparition du modal après échec API.

Ajustement du positionnement modal avec ancrage au bas et marges définies pour éviter la fermeture accidentelle sur mobile.

Gestion du BusyIndicator et affichage dynamique lors du chargement avec suppression de l’affichage intempestif du catalogue avant le chargement complet.